### PR TITLE
Support for HEAD requests

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -3,7 +3,7 @@ import { HeadersMock } from './headers.js';
 import { FetchMockInstance, FetchSpyInstance } from './mock.js';
 import { ResponseMock } from './response.js';
 
-const methods = ['GET', 'POST', 'PATCH', 'PUT', 'DELETE'] as const;
+const methods = ['GET', 'POST', 'PATCH', 'PUT', 'DELETE', 'HEAD'] as const;
 
 export type Method = typeof methods[number];
 export type HeadersMockInit =
@@ -281,6 +281,7 @@ export const mockPost = createAlias('POST');
 export const mockPatch = createAlias('PATCH');
 export const mockDelete = createAlias('DELETE');
 export const mockPut = createAlias('PUT');
+export const mockHead = createAlias('HEAD');
 
 export function createMockFetch({
   baseUrl = '',
@@ -311,5 +312,6 @@ export function createMockFetch({
     mockPatch: createAlias('PATCH'),
     mockDelete: createAlias('DELETE'),
     mockPut: createAlias('PUT'),
+    mockHead: createAlias('HEAD'),
   };
 }


### PR DESCRIPTION
Great helper and easy to use. For my use case, HEAD requests were missing. This PR adds this feature.

Everything was set up, support for HEAD requests in `mockFetch` was already given (with type cast to any).
Adds HEAD to the supported methods and export the helper functions.