### PR TITLE
fix: mock always overridden when adding a second

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -103,7 +103,7 @@ class MockStorage {
 
   clear(fetchMethod: Method, fetchUrl: string | RegExp, removeOnce = true) {
     const predicate = ({ method, path }: CallsStorage) => {
-      return method !== fetchMethod && path !== fetchUrl;
+      return method !== fetchMethod || path !== fetchUrl;
     };
     this.storage = this.storage.filter(predicate);
     if (removeOnce) {

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -263,4 +263,18 @@ describe('reassigning behaviour', () => {
 
     expect(api).toFetchNthTime(3, { data: 55 });
   });
+
+  test('multiple calls', async () => {
+    const api1 = mockGet('/apples');
+    const api2 = mockGet('/pears');
+
+    api1.willResolve({ data: 1 });
+    api2.willResolve({ data: 22 });
+
+    await callApi('/apples');
+    await callApi('/pears');
+
+    expect(api1).toHaveFetched({ data: 1 });
+    expect(api2).toHaveFetched({ data: 22 });
+  });
 });


### PR DESCRIPTION
I ran into the same problem as @cormacmccarthy. After some digging, I found that the storage clear predicate was wrong and is the cause for removing all previously defined routes (with some exceptions).

Fixes #9 